### PR TITLE
Remove local.properties

### DIFF
--- a/local.properties
+++ b/local.properties
@@ -1,9 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Tue Aug 06 18:42:28 IDT 2019
-ndk.dir=/opt/AndroidSdk/ndk-bundle
-sdk.dir=/opt/AndroidSdk


### PR DESCRIPTION
The local.properties file should not be checked in as it contains non-portable local configuration.